### PR TITLE
Bugfix: Coin object properly destroyed after reaching player

### DIFF
--- a/Assets/coinScript.cs
+++ b/Assets/coinScript.cs
@@ -36,10 +36,11 @@ public class coinScript : MonoBehaviour
                 playerTransform.position,
                 magnetSpeed * Time.deltaTime
             );
-            if (Vector2.Distance(transform.position, playerTransform.position) < minDistance)
-            {
-                Destroy(gameObject);
-            }
+        if (Vector2.Distance(transform.position, playerTransform.position) < minDistance)
+        {
+            Debug.Log("Destroy triggert");
+            Destroy(gameObject);
+        }
             
         }
     }


### PR DESCRIPTION
### What’s fixed:
- Coins are now properly destroyed once they reach the player after being magnetized.
- A minimum distance check has been implemented to avoid premature or failed destruction.
- Ensured the Coin's collider is set to trigger to correctly register OnTriggerEnter2D events.

### Why it matters:
Without this fix, coins would stay on screen and interfere with player movement, leading to unintended gameplay bugs.

### How to test:
- Approach coins with the MagnetZone active.
- Observe if the coin moves towards the player and disappears once it's close enough.

🎯 Resolved issue: Unexpected behavior in coin collection.
