### PR TITLE
Feature: Basic score and XP popups added

### DIFF
--- a/Assets/GameManagerScript.cs
+++ b/Assets/GameManagerScript.cs
@@ -13,6 +13,12 @@ public class GameManagerScript : MonoBehaviour
 
     public Text version;
 
+    public Text ScorePopUpText;
+    public GameObject ScorePopUpObject;
+
+    public Text XpPopUpText;
+    public GameObject XpPopUpObject;
+
     // Variablen
     public int score;
     private float xp;
@@ -52,6 +58,9 @@ public class GameManagerScript : MonoBehaviour
     {
         score += scoreAmount;
         scoreText.text = "Score: " + score;
+        ScorePopUpObject.SetActive(true);
+        ScorePopUpText.text = "+" + scoreAmount;
+        Invoke("HideScorePopUpObject", 3f);
     }
 
     public void addXp(int xpAmount)
@@ -62,10 +71,14 @@ public class GameManagerScript : MonoBehaviour
         {
             xp -= xpToLevelUp;
             levelUp();
-            xpToLevelUp = xpToLevelUp * xpToLevelUpFactor; 
+            xpToLevelUp = xpToLevelUp * xpToLevelUpFactor;
+
         }
-        
+
         xpText.text = Mathf.FloorToInt(xp) + " / " + Mathf.FloorToInt(xpToLevelUp);
+        XpPopUpObject.SetActive(true);
+        XpPopUpText.text = "+" + xp + "XP"; 
+        Invoke("HideXpPopUpObject", 3f);
     }
 
     public void levelUp()
@@ -82,5 +95,15 @@ public class GameManagerScript : MonoBehaviour
 
         xpToLevelUp *= xpToLevelUpFactor;
         levelText.text = "Level: " + Level;
+    }
+
+    public void HideScorePopUpObject()
+    {
+        ScorePopUpObject.SetActive(false);
+    }
+
+    public void HideXpPopUpObject()
+    {
+        XpPopUpObject.SetActive(false);
     }
 }

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -119,6 +119,157 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &258683852
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 258683853}
+  m_Layer: 5
+  m_Name: XpPopUpObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &258683853
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 258683852}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 430314564}
+  m_Father: {fileID: 719772109}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &278536493
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 278536494}
+  m_Layer: 5
+  m_Name: ScorePopUpObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &278536494
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 278536493}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1166551497}
+  m_Father: {fileID: 719772109}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &430314563
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 430314564}
+  - component: {fileID: 430314566}
+  - component: {fileID: 430314565}
+  m_Layer: 5
+  m_Name: XpPopUpText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &430314564
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 430314563}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 258683853}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -369, y: 177}
+  m_SizeDelta: {x: 51.9432, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &430314565
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 430314563}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 1, b: 0.43130994, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 12
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: + 15XP
+--- !u!222 &430314566
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 430314563}
+  m_CullTransparentMesh: 1
 --- !u!1 &442070292
 GameObject:
   m_ObjectHideFlags: 0
@@ -546,6 +697,8 @@ RectTransform:
   - {fileID: 451109438}
   - {fileID: 521163626}
   - {fileID: 1066600184}
+  - {fileID: 278536494}
+  - {fileID: 258683853}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -881,6 +1034,85 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1066600183}
   m_CullTransparentMesh: 1
+--- !u!1 &1166551496
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1166551497}
+  - component: {fileID: 1166551499}
+  - component: {fileID: 1166551498}
+  m_Layer: 5
+  m_Name: ScorePopUpText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1166551497
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1166551496}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 278536494}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -373, y: 184}
+  m_SizeDelta: {x: 42.5403, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1166551498
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1166551496}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 1, b: 0.18800211, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 12
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: + 12
+--- !u!222 &1166551499
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1166551496}
+  m_CullTransparentMesh: 1
 --- !u!1 &1404704172
 GameObject:
   m_ObjectHideFlags: 0
@@ -982,6 +1214,10 @@ MonoBehaviour:
   levelText: {fileID: 451109439}
   xpText: {fileID: 521163627}
   version: {fileID: 1066600185}
+  ScorePopUpText: {fileID: 1166551498}
+  ScorePopUpObject: {fileID: 278536493}
+  XpPopUpText: {fileID: 430314565}
+  XpPopUpObject: {fileID: 258683852}
   score: 0
   maxLevel: 30
   Level: 0

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+## [0.2.0] – 2025-05-17
+
+### Added
+- ✨ Basic popup system for score and XP gain
+- Popups appear when collecting coins or gaining XP
+- Popups automatically disappear after 3 seconds
+
 ## [Unreleased]
 ### Fixed
 - 🪙 Coins are now correctly destroyed after reaching the player when magnetized.


### PR DESCRIPTION
### ✨ What’s new:
- Score popup displayed when player gains points
- XP popup shown when XP is awarded
- Both are automatically hidden after a short duration (3s)
- Positioned in UI and triggered via `GameManagerScript`

### 🔧 Notes:
- Currently only supports one active popup per type
- Will be refactored into prefab-based system later for multiple instances

### 🧪 Tested:
- Added score/XP manually and via coin pickup → Popup shown and hides correctly